### PR TITLE
Blacklist always enabled

### DIFF
--- a/ghettorecorder/ghetto_blacklist.py
+++ b/ghettorecorder/ghetto_blacklist.py
@@ -41,9 +41,9 @@ def init(**kwargs):
     helper.radio_name_list = kwargs['radio_name_list']
     helper.config_file_radio_url_dict = kwargs['config_file_radio_url_dict']
 
-    blacklist_enabled = True if kwargs['config_file_settings_dict']['blacklist_enable'] else False
-    ghettoApi.blacklist.blacklist_enable = True if blacklist_enabled else False
-    if blacklist_enabled:
+    true_list = [True, 'y', 'Y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO', 'true', 'True', 'TRUE', '1']
+    ghettoApi.blacklist.blacklist_enable = kwargs['config_file_settings_dict']['blacklist_enable'] in true_list
+    if ghettoApi.blacklist.blacklist_enable:
         blacklist_enable(kwargs['blacklist_name'])
 
 

--- a/ghettorecorder/ghetto_blacklist.py
+++ b/ghettorecorder/ghetto_blacklist.py
@@ -41,7 +41,7 @@ def init(**kwargs):
     helper.radio_name_list = kwargs['radio_name_list']
     helper.config_file_radio_url_dict = kwargs['config_file_radio_url_dict']
 
-    true_list = [True, 'y', 'Y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO', 'true', 'True', 'TRUE', '1']
+    true_list = [True, 'y', 'Y', 'yes', 'Yes', 'YES', 'true', 'True', 'TRUE', '1']
     ghettoApi.blacklist.blacklist_enable = kwargs['config_file_settings_dict']['blacklist_enable'] in true_list
     if ghettoApi.blacklist.blacklist_enable:
         blacklist_enable(kwargs['blacklist_name'])

--- a/ghettorecorder/ghetto_blacklist.py
+++ b/ghettorecorder/ghetto_blacklist.py
@@ -41,7 +41,7 @@ def init(**kwargs):
     helper.radio_name_list = kwargs['radio_name_list']
     helper.config_file_radio_url_dict = kwargs['config_file_radio_url_dict']
 
-    true_list = [True, 'y', 'Y', 'yes', 'Yes', 'YES', 'true', 'True', 'TRUE', '1']
+    true_list = [True, 'y', 'Y', 'yes', 'Yes', 'YES', 'true', 'True', 'TRUE', '1', 1]
     ghettoApi.blacklist.blacklist_enable = kwargs['config_file_settings_dict']['blacklist_enable'] in true_list
     if ghettoApi.blacklist.blacklist_enable:
         blacklist_enable(kwargs['blacklist_name'])


### PR DESCRIPTION
At the moment the feature for disabling the blacklist is broken. 

The dict passed to the responsible method is expected to hold a key with a boolean value, while the value is actually a string. 
The global config section is read via method [ConfigParser.items](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.items) but this method has no ability to convert 'False' into False and bool('False') is True. 

The proposed fix here is least invasive and checks the passed String value according to have a common-sense value (derived from the Yaml 1.1 spec actually). 

An alternative would have been to introduce [ConfigParser.getboolean](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.getboolean) but that seemed rocket science to me as this is the only boolean value in the exposed configuration. 
